### PR TITLE
various small fixes

### DIFF
--- a/proof-pile-v2/arXiv/raw_pilev2_to_jsonl.py
+++ b/proof-pile-v2/arXiv/raw_pilev2_to_jsonl.py
@@ -2,11 +2,14 @@ import sys
 import os
 import json
 import datasets 
+from datasets import disable_caching
 import argparse
 from tqdm import tqdm
 import code
 from pathlib import Path
 import ast
+
+disable_caching()
 
 EVAL_RATIO=0.005
 
@@ -64,13 +67,23 @@ def main(args):
     print("VALIDATION", len(validation))
     print("TEST", len(test))
 
-    validation.to_json(
+    validation.map(
+            fix_meta, 
+            num_proc=args.cpus,
+        ).remove_columns(
+                columns_to_remove
+        ).to_json(
             os.path.join(outdir, "validation", f"{name}.jsonl"), 
             lines=True, 
             num_proc=args.cpus
     )
 
-    test.to_json(
+    test.map(
+            fix_meta, 
+            num_proc=args.cpus,
+        ).remove_columns(
+                columns_to_remove
+        ).to_json(
             os.path.join(outdir, "test", f"{name}.jsonl"), 
             lines=True, 
             num_proc=args.cpus

--- a/proof-pile-v2/arXiv/raw_pilev2_to_jsonl.py
+++ b/proof-pile-v2/arXiv/raw_pilev2_to_jsonl.py
@@ -54,11 +54,11 @@ def main(args):
             fix_meta, 
             num_proc=args.cpus,
         ).remove_columns(
-                columns_to_remove
+            columns_to_remove
         ).to_json(
-                os.path.join(outdir, "train", f"{name}_{str(shard).zfill(3)}.jsonl"), 
-                lines=True,
-                num_proc=args.cpus,
+            os.path.join(outdir, "train", f"{name}_{str(shard).zfill(3)}.jsonl"), 
+            lines=True,
+            num_proc=args.cpus,
         )
 
     # Validation and test
@@ -71,7 +71,7 @@ def main(args):
             fix_meta, 
             num_proc=args.cpus,
         ).remove_columns(
-                columns_to_remove
+            columns_to_remove
         ).to_json(
             os.path.join(outdir, "validation", f"{name}.jsonl"), 
             lines=True, 
@@ -82,7 +82,7 @@ def main(args):
             fix_meta, 
             num_proc=args.cpus,
         ).remove_columns(
-                columns_to_remove
+            columns_to_remove
         ).to_json(
             os.path.join(outdir, "test", f"{name}.jsonl"), 
             lines=True, 

--- a/proof-pile-v2/issues_diffs/download_from_pilev2.sh
+++ b/proof-pile-v2/issues_diffs/download_from_pilev2.sh
@@ -7,5 +7,5 @@ mkdir -p raw_pilev2/GithubIssues
 
 aws s3 cp s3://s-eai-neox/data/pilev2/pilev2_local_deduped/GithubDiff_ver2/ raw_pilev2/GithubDiff --recursive
 
-aws s3 cp s3://s-eai-neox/data/pilev2/pilev2_local_deduped/GithubIssues/ raw_pilev2/GithubIssues --recursive
+aws s3 cp s3://s-eai-neox/data/pilev2/pilev2_local_deduped/GithubIssues_dedup/ raw_pilev2/GithubIssues --recursive
 


### PR DESCRIPTION
1. Adds to neox gitignore
2. Fixes uninitialized variable in tokenization loop
3. Changes name of neox subset proof pile subset from `proof-pile-1.2` to `proof-pile`.
4. makes columns of arXiv dataset consistent between different splits.
5. Fixes s3 path for downloading github issues.