### PR TITLE
Fixes to process_stack.py

### DIFF
--- a/proof-pile-v2/source_code/process_stack.py
+++ b/proof-pile-v2/source_code/process_stack.py
@@ -185,9 +185,14 @@ def c_filter(example):
     text = example["content"]
     keywords = [
         "#include <fftw.h>",
+        "#include <fftw3.h>"
         "#include <rfftw.h>",
         "#include <gsl",
         "#include <cblas.h>",
+        "#include <blas.h>",
+        "#include <lapacke.h>",
+        "#include <nlopt.h>",
+        "#include <petsc.h>"
     ]
 
     found = [x for x in keywords if x in text]
@@ -499,12 +504,12 @@ def main(args):
         # counts number of files and dataset byte size and tokens in single loop
         print("calculating dataset statistics...")
         files, size, tokens = reduce(
-            lambda x, y: (x[0] + 1, x[1] + y["size"], x[2] + y["tokens"]),
+            lambda x, y: (x[0] + 1, x[1] + y["size"], x[2] + y["num_tokens"]),
             tqdm(ds),
             (0, 0, 0),
         )
 
-        stats_of_lang = {"files": files, "size": size, "tokens": tokens}
+        stats_of_lang = {"files": files, "size": size, "num_tokens": tokens}
 
         print("printing stats...")
         print(stats_of_lang)


### PR DESCRIPTION
1. Add a few more packages the `c_filter` in `process_stack.py`. Admittedly, this only adds 10 million or so tokens.
2. Fix a bug introduced in #42, where not every instance of the "tokens" key was changed to "num_tokens".