### PR TITLE
Faster repo name extraction

### DIFF
--- a/proof-pile-v2/source_code/process_github.py
+++ b/proof-pile-v2/source_code/process_github.py
@@ -35,7 +35,7 @@ TEXT_MAX_SIZE = 1048575  # in bytes
 MAX_NUMERICAL_DENSITY = .5
 MAX_SIZE_BYTES=1e9 # maximum size of repo tarball
 
-INIT_DATE="2023-01-01" # iso datestring
+INIT_DATE="2009-01-01" # iso datestring
 
 def week_intervals(
         start=datetime.fromisoformat(INIT_DATE).replace(tzinfo=timezone.utc), 


### PR DESCRIPTION
#49 introduced code that uses exponential backoff to stay within Github's rate limit when extracting language repo lists from the search API. Exponential backoff is good for minimizing latency but bad for maximizing throughput, since rejected requests count towards the rate limit. 

The solution that maximizes throughput is to use fixed interval backoff. This can be achieved by catching exceptions and `time.sleep()`ing until the rate limit refreshes or via a function decorator from the `backoff` library. I opted for the former because even though it involves nested `while True:` blocks, it is still simpler than any metaprogramming or monkey patching solution for wrapping `__next__` in a decorator. 

I also placed the function call that saves the repo list earlier in the code. For very large numbers of repos extracting the list takes a long time, therefore we want to save the list as early as possible in case the program crashes for some reason. 