### PR TITLE
Change all submodules to http

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,10 @@
 	url = https://github.com/zhangir-azerbayev/MetaMath.git
 [submodule "llemma_formal2formal"]
 	path = llemma_formal2formal
-	url = git@github.com:wellecks/llemma_formal2formal.git
+	url = https://github.com/wellecks/llemma_formal2formal.git
 [submodule "overlap"]
 	path = overlap
-	url = git@github.com:wellecks/overlap.git
+	url = https://github.com/wellecks/overlap.git
 [submodule "lm-evaluation-harness"]
 	path = lm-evaluation-harness
 	url = https://github.com/wellecks/lm-evaluation-harness


### PR DESCRIPTION
In `main`, some submodules use http links and others use ssh links. This can cause some submodules to correctly initialize while others fail, for example as in #82. This PR edits .gitmodules so that all submodules use http links.